### PR TITLE
chore: change pre-commit hook behavior

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,4 @@
 
 . "$(dirname -- "$0")/_/husky.sh"
 
-npm run lint:fix && npm run format:write && git add .
+npm run lint:fix && npm run format:write


### PR DESCRIPTION
At now, all changes in directory forced to be added to commit by pre-commit hook.
This behavior is dangerous.
It is because we cannot notice unintentional additions of files.

