### PR TITLE
Eliminate OpenRouter model retrieval logic

### DIFF
--- a/app/[locale]/setup/page.tsx
+++ b/app/[locale]/setup/page.tsx
@@ -7,7 +7,7 @@ import {
   getWorkspacesByUserId
 } from "@/db/workspaces"
 import {
-  fetchHostedModels,
+  fetchHostedModels
   // fetchOpenRouterModels
 } from "@/lib/models/fetch-models"
 import { supabase } from "@/lib/supabase/browser-client"

--- a/app/[locale]/setup/page.tsx
+++ b/app/[locale]/setup/page.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/db/workspaces"
 import {
   fetchHostedModels,
-  fetchOpenRouterModels
+  // fetchOpenRouterModels
 } from "@/lib/models/fetch-models"
 import { supabase } from "@/lib/supabase/browser-client"
 import { TablesUpdate } from "@/supabase/types"
@@ -84,11 +84,11 @@ export default function SetupPage() {
           setEnvKeyMap(data.envKeyMap)
           setAvailableHostedModels(data.hostedModels)
 
-          if (profile["openrouter_api_key"] || data.envKeyMap["openrouter"]) {
-            const openRouterModels = await fetchOpenRouterModels()
-            if (!openRouterModels) return
-            setAvailableOpenRouterModels(openRouterModels)
-          }
+          // if (profile["openrouter_api_key"] || data.envKeyMap["openrouter"]) {
+          //   const openRouterModels = await fetchOpenRouterModels()
+          //   if (!openRouterModels) return
+          //   setAvailableOpenRouterModels(openRouterModels)
+          // }
 
           const homeWorkspaceId = await getHomeWorkspaceByUserId(
             session.user.id

--- a/components/utility/global-state.tsx
+++ b/components/utility/global-state.tsx
@@ -9,7 +9,7 @@ import { getSubscriptionByUserId } from "@/db/subscriptions"
 import { getWorkspacesByUserId } from "@/db/workspaces"
 import { convertBlobToBase64 } from "@/lib/blob-to-b64"
 import {
-  fetchHostedModels,
+  fetchHostedModels
   // fetchOllamaModels,
   // fetchOpenRouterModels
 } from "@/lib/models/fetch-models"

--- a/components/utility/global-state.tsx
+++ b/components/utility/global-state.tsx
@@ -11,7 +11,7 @@ import { convertBlobToBase64 } from "@/lib/blob-to-b64"
 import {
   fetchHostedModels,
   // fetchOllamaModels,
-  fetchOpenRouterModels
+  // fetchOpenRouterModels
 } from "@/lib/models/fetch-models"
 import { supabase } from "@/lib/supabase/browser-client"
 import { Tables } from "@/supabase/types"
@@ -136,14 +136,14 @@ export const GlobalState: FC<GlobalStateProps> = ({ children }) => {
         setEnvKeyMap(hostedModelRes.envKeyMap)
         setAvailableHostedModels(hostedModelRes.hostedModels)
 
-        if (
-          profile["openrouter_api_key"] ||
-          hostedModelRes.envKeyMap["openrouter"]
-        ) {
-          const openRouterModels = await fetchOpenRouterModels()
-          if (!openRouterModels) return
-          setAvailableOpenRouterModels(openRouterModels)
-        }
+        // if (
+        //   profile["openrouter_api_key"] ||
+        //   hostedModelRes.envKeyMap["openrouter"]
+        // ) {
+        //   const openRouterModels = await fetchOpenRouterModels()
+        //   if (!openRouterModels) return
+        //   setAvailableOpenRouterModels(openRouterModels)
+        // }
       }
 
       //   if (process.env.NEXT_PUBLIC_OLLAMA_URL) {

--- a/components/utility/profile-settings.tsx
+++ b/components/utility/profile-settings.tsx
@@ -8,7 +8,7 @@ import {
 import { updateProfile } from "@/db/profile"
 import { uploadProfileImage } from "@/db/storage/profile-images"
 import { exportLocalStorageAsJSON } from "@/lib/export-old-data"
-import { fetchOpenRouterModels } from "@/lib/models/fetch-models"
+// import { fetchOpenRouterModels } from "@/lib/models/fetch-models"
 import { LLM_LIST_MAP } from "@/lib/models/llm/llm-list"
 import { supabase } from "@/lib/supabase/browser-client"
 import { cn } from "@/lib/utils"
@@ -191,19 +191,19 @@ export const ProfileSettings: FC<ProfileSettingsProps> = ({}) => {
         const hasApiKey = !!updatedProfile[providerKey]
 
         if (provider === "openrouter") {
-          if (hasApiKey && availableOpenRouterModels.length === 0) {
-            const openrouterModels: OpenRouterLLM[] =
-              await fetchOpenRouterModels()
-            setAvailableOpenRouterModels(prev => {
-              const newModels = openrouterModels.filter(
-                model =>
-                  !prev.some(prevModel => prevModel.modelId === model.modelId)
-              )
-              return [...prev, ...newModels]
-            })
-          } else {
+          // if (hasApiKey && availableOpenRouterModels.length === 0) {
+          //   const openrouterModels: OpenRouterLLM[] =
+          //     await fetchOpenRouterModels()
+          //   setAvailableOpenRouterModels(prev => {
+          //     const newModels = openrouterModels.filter(
+          //       model =>
+          //         !prev.some(prevModel => prevModel.modelId === model.modelId)
+          //     )
+          //     return [...prev, ...newModels]
+          //   })
+          // } else {
             setAvailableOpenRouterModels([])
-          }
+          // }
         } else {
           if (hasApiKey && Array.isArray(models)) {
             setAvailableHostedModels(prev => {

--- a/components/utility/profile-settings.tsx
+++ b/components/utility/profile-settings.tsx
@@ -202,7 +202,7 @@ export const ProfileSettings: FC<ProfileSettingsProps> = ({}) => {
           //     return [...prev, ...newModels]
           //   })
           // } else {
-            setAvailableOpenRouterModels([])
+          setAvailableOpenRouterModels([])
           // }
         } else {
           if (hasApiKey && Array.isArray(models)) {

--- a/components/utility/settings.tsx
+++ b/components/utility/settings.tsx
@@ -205,7 +205,7 @@ export const Settings: FC<ProfileSettingsProps> = ({}) => {
           //     return [...prev, ...newModels]
           //   })
           // } else {
-            setAvailableOpenRouterModels([])
+          setAvailableOpenRouterModels([])
           // }
         } else {
           if (hasApiKey && Array.isArray(models)) {

--- a/components/utility/settings.tsx
+++ b/components/utility/settings.tsx
@@ -8,7 +8,7 @@ import {
 import { updateProfile } from "@/db/profile"
 import { uploadProfileImage } from "@/db/storage/profile-images"
 import { exportLocalStorageAsJSON } from "@/lib/export-old-data"
-import { fetchOpenRouterModels } from "@/lib/models/fetch-models"
+// import { fetchOpenRouterModels } from "@/lib/models/fetch-models"
 import { LLM_LIST_MAP } from "@/lib/models/llm/llm-list"
 import { supabase } from "@/lib/supabase/browser-client"
 import { cn } from "@/lib/utils"
@@ -194,19 +194,19 @@ export const Settings: FC<ProfileSettingsProps> = ({}) => {
         const hasApiKey = !!updatedProfile[providerKey]
 
         if (provider === "openrouter") {
-          if (hasApiKey && availableOpenRouterModels.length === 0) {
-            const openrouterModels: OpenRouterLLM[] =
-              await fetchOpenRouterModels()
-            setAvailableOpenRouterModels(prev => {
-              const newModels = openrouterModels.filter(
-                model =>
-                  !prev.some(prevModel => prevModel.modelId === model.modelId)
-              )
-              return [...prev, ...newModels]
-            })
-          } else {
+          // if (hasApiKey && availableOpenRouterModels.length === 0) {
+          //   const openrouterModels: OpenRouterLLM[] =
+          //     await fetchOpenRouterModels()
+          //   setAvailableOpenRouterModels(prev => {
+          //     const newModels = openrouterModels.filter(
+          //       model =>
+          //         !prev.some(prevModel => prevModel.modelId === model.modelId)
+          //     )
+          //     return [...prev, ...newModels]
+          //   })
+          // } else {
             setAvailableOpenRouterModels([])
-          }
+          // }
         } else {
           if (hasApiKey && Array.isArray(models)) {
             setAvailableHostedModels(prev => {

--- a/lib/models/fetch-models.ts
+++ b/lib/models/fetch-models.ts
@@ -67,35 +67,35 @@ export const fetchHostedModels = async (profile: Tables<"profiles">) => {
 //   }
 // }
 
-export const fetchOpenRouterModels = async () => {
-  try {
-    const response = await fetch("https://openrouter.ai/api/v1/models")
+// export const fetchOpenRouterModels = async () => {
+//   try {
+//     const response = await fetch("https://openrouter.ai/api/v1/models")
 
-    if (!response.ok) {
-      throw new Error(`OpenRouter server is not responding.`)
-    }
+//     if (!response.ok) {
+//       throw new Error(`OpenRouter server is not responding.`)
+//     }
 
-    const { data } = await response.json()
+//     const { data } = await response.json()
 
-    const openRouterModels = data.map(
-      (model: {
-        id: string
-        name: string
-        context_length: number
-      }): OpenRouterLLM => ({
-        modelId: model.id as LLMID,
-        modelName: model.id,
-        provider: "openrouter",
-        hostedId: model.name,
-        platformLink: "https://openrouter.dev",
-        imageInput: false,
-        maxContext: model.context_length
-      })
-    )
+//     const openRouterModels = data.map(
+//       (model: {
+//         id: string
+//         name: string
+//         context_length: number
+//       }): OpenRouterLLM => ({
+//         modelId: model.id as LLMID,
+//         modelName: model.id,
+//         provider: "openrouter",
+//         hostedId: model.name,
+//         platformLink: "https://openrouter.dev",
+//         imageInput: false,
+//         maxContext: model.context_length
+//       })
+//     )
 
-    return openRouterModels
-  } catch (error) {
-    console.error("Error fetching Open Router models: " + error)
-    toast.error("Error fetching Open Router models: " + error)
-  }
-}
+//     return openRouterModels
+//   } catch (error) {
+//     console.error("Error fetching Open Router models: " + error)
+//     toast.error("Error fetching Open Router models: " + error)
+//   }
+// }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17776,6 +17776,111 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.1.0.tgz",
+      "integrity": "sha512-nUDn7TOGcIeyQni6lZHfzNoo9S0euXnu0jhsbMOmMJUBfgsnESdjN97kM7cBqQxZa8L/bM9om/S5/1dzCrW6wQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.1.0.tgz",
+      "integrity": "sha512-1jgudN5haWxiAl3O1ljUS2GfupPmcftu2RYJqZiMJmmbBT5M1XDffjUtRUzP4W3cBHsrvkfOFdQ71hAreNQP6g==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.1.0.tgz",
+      "integrity": "sha512-RHo7Tcj+jllXUbK7xk2NyIDod3YcCPDZxj1WLIYxd709BQ7WuRYl3OWUNG+WUfqeQBds6kvZYlc42NJJTNi4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.1.0.tgz",
+      "integrity": "sha512-v6kP8sHYxjO8RwHmWMJSq7VZP2nYCkRVQ0qolh2l6xroe9QjbgV8siTbduED4u0hlk0+tjS6/Tuy4n5XCp+l6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.1.0.tgz",
+      "integrity": "sha512-o1N5TsYc8f/HpGt39OUQpQ9AKIGApd3QLueu7hXk//2xq5Z9OxmV6sQfNp8C7qYmiOlHYODOGqNNa0e9jvchGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.1.0.tgz",
+      "integrity": "sha512-XXIuB1DBRCFwNO6EEzCTMHT5pauwaSj4SWs7CYnME57eaReAKBXCnkUE80p/pAZcewm7hs+vGvNqDPacEXHVkw==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.1.0.tgz",
+      "integrity": "sha512-9WEbVRRAqJ3YFVqEZIxUqkiO8l1nool1LmNxygr5HWF8AcSYsEpneUDhmjUVJEzO2A04+oPtZdombzzPPkTtgg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }


### PR DESCRIPTION
Removed the fetchOpenRouterModels logic due to its unnecessary invocation at every operation and the recurrent errors it produced when failing to execute as expected. This change streamlines the process by eliminating redundant data retrieval steps, enhancing the system's efficiency and reliability.