### PR TITLE
Ensure absolute URLs for OG and Twitter card images

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -55,7 +55,7 @@ export const metadata: Metadata = {
     description: APP_DESCRIPTION,
     images: [
       {
-        url: "/icon-512x512.png",
+        url: "https://chat.hackerai.co/icon-512x512.png",
         width: 512,
         height: 512,
         alt: "HackerGPT"
@@ -71,7 +71,7 @@ export const metadata: Metadata = {
     description: APP_DESCRIPTION,
     images: [
       {
-        url: "/icon-512x512.png",
+        url: "https://chat.hackerai.co/icon-512x512.png",
         width: 512,
         height: 512,
         alt: "HackerGPT"


### PR DESCRIPTION
This commit updates the social metadata configuration to use absolute URLs for Open Graph and Twitter card images, resolving the issue where social platforms could not correctly fetch the images due to relative paths.