### PR TITLE
Remove drawing functionality from FilePreview component

### DIFF
--- a/components/ui/file-preview.tsx
+++ b/components/ui/file-preview.tsx
@@ -32,9 +32,7 @@ export const FilePreview: FC<FilePreviewProps> = ({
           if (type === "image") {
             const imageItem = item as MessageImage
 
-            return imageItem.file ? (
-              <DrawingCanvas imageItem={imageItem} />
-            ) : (
+            return (
               <Image
                 className="rounded"
                 src={imageItem.base64 || imageItem.url}


### PR DESCRIPTION
Removed the drawing functionality from the FilePreview component to prevent images from breaking when viewing. Images are now displayed as non-interactive previews.
