### PR TITLE
Save Enhance Menu State (Open/Close) into Supabase

### DIFF
--- a/components/chat/chat-input.tsx
+++ b/components/chat/chat-input.tsx
@@ -1,5 +1,7 @@
 import Modal from "@/components/chat/dialog-portal"
 import { ChatbotUIContext } from "@/context/context"
+import {getProfileByUserId, updateProfile} from "@/db/profile"
+
 import useHotkey from "@/lib/hooks/use-hotkey"
 import { LLM_LIST } from "@/lib/models/llm/llm-list"
 import { GPT4 } from "@/lib/models/llm/openai-llm-list"
@@ -36,6 +38,8 @@ import useSpeechRecognition from "./chat-hooks/use-speech-recognition"
 import { IconMicrophone } from "@tabler/icons-react"
 import VoiceRecordingBar from "@/components/ui/voice-recording-bar"
 import VoiceLoadingBar from "../ui/voice-loading-bar"
+import {supabase} from "@/lib/supabase/browser-client";
+import {TablesUpdate} from "@/supabase/types";
 
 interface ChatInputProps {}
 
@@ -105,8 +109,29 @@ export const ChatInput: FC<ChatInputProps> = ({}) => {
   } = useChatHandler()
 
   const handleToggleEnhancedMenu = () => {
-    setIsEnhancedMenuOpen(!isEnhancedMenuOpen)
+    const newStatus = !isEnhancedMenuOpen;
+    setIsEnhancedMenuOpen(newStatus);
+
+    (async () => {
+      await updateEnhancedMenuStatus(newStatus);
+    })();
+
   }
+
+  const updateEnhancedMenuStatus = async (newStatus: boolean) => {
+    try {
+      const session = (await supabase.auth.getSession()).data.session
+
+      if (session) {
+        const user = session.user;
+        const profile = await getProfileByUserId(user.id);
+        profile.is_enhanced_menu_open = newStatus;
+        await updateProfile(profile.id, profile)
+      }
+    } catch (error) {
+      console.error('Error updating enhanced menu status:', error);
+    }
+  };
 
   const handleToggleRAG = (e: React.MouseEvent) => {
     setIsRagEnabled(!isRagEnabled)

--- a/components/utility/global-state.tsx
+++ b/components/utility/global-state.tsx
@@ -3,7 +3,7 @@
 "use client"
 
 import { ChatbotUIContext } from "@/context/context"
-import { getProfileByUserId } from "@/db/profile"
+import {getProfileByUserId} from "@/db/profile"
 import { getWorkspaceImageFromStorage } from "@/db/storage/workspace-images"
 import { getSubscriptionByUserId } from "@/db/subscriptions"
 import { getWorkspacesByUserId } from "@/db/workspaces"
@@ -170,6 +170,8 @@ export const GlobalState: FC<GlobalStateProps> = ({ children }) => {
       if (!profile.has_onboarded) {
         return router.push("/setup")
       }
+
+      setIsEnhancedMenuOpen(profile.is_enhanced_menu_open ?? true);
 
       const subscription = await getSubscriptionByUserId(user.id)
       setSubscription(subscription)

--- a/supabase/migrations/20240619122400_add_is_enhanced_menu_open_to_profile.sql
+++ b/supabase/migrations/20240619122400_add_is_enhanced_menu_open_to_profile.sql
@@ -1,0 +1,1 @@
+ALTER TABLE profiles ADD COLUMN is_enhanced_menu_open BOOLEAN DEFAULT TRUE;


### PR DESCRIPTION
Description

Currently, the enhance menu, which includes the plugin picker, is closed every time the page is reloaded. If a user opens the menu and then reloads the page, the menu will be closed again. To improve the user experience, we should store the enhance menu state (open or closed) in the database and restore it every time the page is reloaded.



